### PR TITLE
sidebar package explorer and breadcrumbs

### DIFF
--- a/asset/css/doc.css
+++ b/asset/css/doc.css
@@ -169,3 +169,128 @@ div.odoc-include summary:hover {
 div.odoc span[class*="keyword"] {
   color: rgba(17, 24, 39, 1);
 }
+
+/* package explorer navmap and breadcrumb tag */
+
+.navmap:hover ul {
+  border-color: gainsboro;
+}
+
+.no-expand, .icon-expand  {
+  white-space:nowrap;
+  display:flex;
+  flex-wrap: nowrap;
+}
+
+.icon-expand {
+  cursor: pointer;
+}
+
+span.icon-expand:not(.open) > .navmap-tag , span.no-expand > .navmap-tag {
+  background:white;
+}
+
+.navmap-tag {
+  display:flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width:2.1em;
+  min-width:2.1em;
+  margin:3px 0;
+  padding:2px 1px;
+  line-height:1;
+  margin-right:6px;
+  font-family: Inter, sans-serif;
+  border-width: 2px;
+  border-radius: 0.25em;
+  font-weight:bold;
+  font-size: .875rem;
+  box-sizing: border-box;
+}
+
+.navmap-tag.library-tag::after {
+  content: "lib";
+}
+.library-tag {
+  color: rgb(91, 102, 114);
+  background-color: rgb(91, 102, 114);
+  border-color: rgb(91, 102, 114);
+}
+.navmap-tag.module-tag::after {
+  content: "M";
+}
+.module-tag {
+  color: #cc4e0c;
+  background-color: #cc4e0c;
+  border-color: #cc4e0c;
+}
+.navmap-tag.module-type-tag::after {
+  content: "Mt";
+}
+.module-type-tag{
+  color: #027491;
+  background-color: #027491;
+  border-color: #027491;
+}
+.navmap-tag.parameter-tag::after {
+  content: "P";
+}
+.parameter-tag{
+  color: green;
+  background-color: green;
+  border-color: green;
+}
+.navmap-tag.class-tag::after {
+  content: "C";
+}
+.class-tag{
+  color: rgb(163, 34, 34);
+  background-color: rgb(163, 34, 34);
+  border-color: rgb(163, 34, 34);
+}
+.navmap-tag.class-type-tag::after {
+  content: "Ct";
+}
+.class-type-tag{
+  color: rgb(32, 68, 165);
+  background-color: rgb(32, 68, 165);
+  border-color: rgb(32, 68, 165);
+}
+
+span.no-expand > .navmap-tag {
+  margin-left: 12px;
+}
+
+span.icon-expand.open > .navmap-tag {
+  color:white;
+}
+
+span.icon-expand::before {
+  font-weight: bold;
+  content: " \25B8";
+  text-align: center;
+  box-sizing: border-box;
+  display:flex;
+  align-items: center;
+  padding-right:4px;
+}
+
+span.icon-expand.open::before {
+  content: " \25BE";
+}
+
+.breadcrumbs-tag {
+  padding:2px 6px;
+  line-height:1;
+  margin-right:6px;
+  font-family: Inter, sans-serif;
+  border-width: 2px;
+  border-radius: 0.25em;
+  font-weight:bold;
+  font-size: 1rem;
+  box-sizing: border-box;
+  color:white;
+  align-items: center;
+  display:flex;
+}

--- a/src/ocamlorg_frontend/components/breadcrumbs.eml
+++ b/src/ocamlorg_frontend/components/breadcrumbs.eml
@@ -1,40 +1,68 @@
-let module_kind = function
-  | `Module _ -> "Module"
-  | `ModuleType _ -> "Module type"
-  | `FunctorArgument (number, _) -> "Parameter #" ^ (Int.to_string number)
+type path_item = 
+  | Page of string
+  | Library of string
+  | Module of string
+  | ModuleType of string
+  | FunctorArgument of int * string
+  | Class of string
+  | ClassType of string
 
-let module_path_kind path =
-  match List.fold_left (fun _ v -> Some v) None path with 
-  | None -> ""
-  | Some v -> module_kind v
+let kind_tag (m : path_item) = match m with
+  | Page _ -> ""
+  | Library _ -> ""
+  | Module _ ->
+    <span class="breadcrumbs-tag module-tag text-white">Module</span>
+  | ModuleType _ ->
+    <span class="breadcrumbs-tag module-type-tag text-white">Module type</span>
+  | FunctorArgument (number, _) ->
+    <span class="breadcrumbs-tag parameter-tag text-white"><%s "Parameter #" ^ (Int.to_string number) %></span>
+  | Class _ ->
+    <span class="breadcrumbs-tag class-tag text-white">Class</span>
+  | ClassType _ ->
+    <span class="breadcrumbs-tag class-type-tag text-white">Class type</span>
 
-let module_name = function
-  | `Module name
-  | `ModuleType name
-  | `FunctorArgument (_, name) -> name
+let path_item_name (m: path_item) = match m with
+  | Page name
+  | Library name
+  | Module name
+  | ModuleType name
+  | FunctorArgument (_, name) -> name
+  | Class name -> name
+  | ClassType name -> name
 
-let render module_path =
-  let n_items = List.length module_path in
-  let _item_class index =
-    if index == n_items - 1 then
-      "text-orange-600 border-orange-600 border-b-2"
-    else
-      "hover:text-gray-900 hover:border-gray-400 hover:border-b-2 border-transparent border-b-2"
-  in
-  let item_href index =
-    let rec href_url index =
-      if index == n_items - 1 then "" else
-      "../" ^ href_url (index + 1)
-    in
-    if index == n_items - 1 then "" else
-    "href='"^(href_url index)^"index.html'"
-  in
-  <div class="flex pb-4">
-    <span class="mr-4 mt-2 text-sm font-light inline-block align-bottom"><%s module_path_kind module_path %></span>
-    <% module_path |> List.iteri (fun index item -> %>
-    <% if index > 0 then ( %><span class="ml-1">.</span><% ); %>
+type breadcrumb = {
+  text : string;
+  href : string;
+}
+
+let rec breadcrumbs_from_path (reversed_module_path: path_item list) prefix : ( breadcrumb list ) = match reversed_module_path with
+  | [] -> []
+  | x::[] -> [{ text = path_item_name x; href = prefix ^ "index.html"}]
+  | x::xs ->
+    let new_prefix = prefix ^ "../" in
+    { text = path_item_name x ; href = prefix ^ "index.html" } :: breadcrumbs_from_path xs new_prefix
+
+let render_sidebar_breadcrumbs (module_path : path_item list) =
+  let (reversed_module_path : path_item list) = List.rev module_path in
+  let breadcrumbs = breadcrumbs_from_path reversed_module_path "" in
+  let render_breadcrumb b = 
     <span>
-      <a <%s! item_href index %> class="ml-1 text-2xl font-medium text-gray-800 hover:text-black"><%s module_name item %></a>
+      <a href="<%s! b.href %>" class="font-medium text-gray-800 transition-colors hover:text-orange-600"><%s b.text %></a>
     </span>
-    <% ); %>
+  in
+  <div class="flex flex-wrap">
+    <%s! String.concat "<span>.</span>" (breadcrumbs |> List.rev |> List.map render_breadcrumb)  %>
+  </div>
+
+let render (module_path:path_item list) =
+  let (reversed_module_path : path_item list) = List.rev module_path in
+  let breadcrumbs = breadcrumbs_from_path reversed_module_path "" in
+  let render_breadcrumb b =
+    <span>
+      <a href="<%s! b.href %>" class="ml-1 text-2xl font-medium text-gray-800 transition-colors hover:text-orange-600"><%s b.text %></a>
+    </span>
+  in
+  <div class="flex flex-wrap pb-4">
+    <%s! if module_path != [] then kind_tag (List.hd reversed_module_path) else "" %>
+    <%s! String.concat "<span class=\"ml-1 text-2xl\">.</span>" (breadcrumbs |> List.rev |> List.map render_breadcrumb); %>
   </div>

--- a/src/ocamlorg_frontend/components/navmap.eml
+++ b/src/ocamlorg_frontend/components/navmap.eml
@@ -1,6 +1,7 @@
 type kind =
-  | Module
+  | Library
   | Page
+  | Module
   | Leaf_page
   | Module_type
   | Argument
@@ -9,74 +10,122 @@ type kind =
   | File
 
 type toc = {
-title : string;
-kind : kind;
-href : string option;
-children : toc list
+  title : string;
+  kind : kind;
+  href : string option;
+  children : toc list
 }
 
 type t = toc list
 
-let summary = function
-  | Page -> "library"
-  | Module -> "module"
-  | Module_type -> "module type"
-  | Argument -> "argument"
-  | _ -> ""
+let kind_title = function
+  | Library -> "Library"
+  | Page -> "Page"
+  | Module -> "Module"
+  | Module_type -> "Module type"
+  | Argument -> "Parameter"
+  | Class -> "Class"
+  | Class_type -> "Class type"
+  | _ -> "?"
+
+let title_style = "flex-1 flex-nowrap py-1 md:py-0.5 pr-1 text-gray-600"
+
+let icon_style = function
+  | Library -> "navmap-tag library-tag"
+  | Module -> "navmap-tag module-tag"
+  | Module_type -> "navmap-tag module-type-tag"
+  | Argument -> "navmap-tag parameter-tag"
+  | Class -> "navmap-tag class-tag"
+  | Class_type -> "navmap-tag class-type-tag"
+  | _ -> "navmap-tag"
 
 let rec nested_render ~path (item : toc) =
   match item.children with
   | [] ->
-    <div class="pl-4 py-2 text-sm">
-      <span class="capitalize small-caps font-light"><%s! summary item.kind %></span>
-      <% (match item.href with | None -> %>
-        <span class="font-medium text-gray-900"><%s! item.title %></span>
-      <% | Some href -> %>
-      <a href="<%s href %>" class="font-medium text-gray-900 hover:text-orange-600">
-        <%s! item.title %>
-      </a>
-      <% ); %>
+    let fragment = match path with
+      | v :: _ -> v
+      | [] -> ""
+    in
+    let active_style = if item.title = fragment then "bg-gray-200 border-gray-500 font-medium" else "border-transparent" in
+    if fragment != "" && item.kind = Library && fragment != item.title then "" else
+    <div class="box-border border <%s active_style %> pl-1 ml-1">
+      <div class="flex flex-nowrap" title="<%s kind_title item.kind ^ " " ^ item.title %>">
+        <% (match item.href with | None -> %>
+          <span class="no-expand"><span class="<%s if item.title = fragment then "" else "opacity-80" %> <%s icon_style item.kind %>"></span></span>
+          <span class="sm <%s title_style %>"><%s! item.title %></span>
+        <% | Some href -> %>
+        <a href="<%s href %>" class="flex">
+        <span class="no-expand"><span class="<%s if item.title = fragment then "" else "opacity-80" %> <%s icon_style item.kind %>"></span></span>
+        </a>
+        <a href="<%s href %>" class="<%s title_style %> overflow-hidden truncate text-gray-900 transition-colors hover:text-orange-600">
+          <%s! item.title %>
+        </a>
+        <% ); %>
+      </div>
     </div>
   | children ->
-    let default_open, path = match path with
-      | v :: rest when v = item.title -> (true, rest)
-      | v -> (item.kind = Page, v)
+    let default_open, path, fragment = match path with
+      | v :: rest when v = item.title || v == "" -> (true, rest, v) (* TODO: we need a way to know that the path item is a standalone page *)
+      | v :: _ -> (false, [], v)
+      | [] -> (item.kind = Library && (List.length item.children <= 2), [], "")
     in
-    <details <%s if default_open then "open" else "" %>>
-      <summary class="py-2 hover:bg-gray-100 cursor-pointer text-sm">
-        <span class="pl-4 py-2">
-          <span class="capitalize small-caps font-light"><%s! summary item.kind %></span>
+    let active_style = if item.title = fragment then (if List.length path = 0 then "bg-gray-200 border-gray-500 font-medium" else "border-transparent bg-gray-100 font-medium") else "border-transparent" in
+    if fragment != "" && item.kind = Library && fragment != item.title then "" else
+    <div x-data="{ open: <%s if default_open then "true" else "false" %> }">
+      <div class="box-border border <%s active_style %> cursor-pointer ml-1 pl-1">
+        <div class="flex flex-nowrap" title="<%s kind_title item.kind ^ " " ^ item.title %>">
+          <span class="icon-expand" x-on:click="open = ! open" :class="open ? 'open' : ''" >
+            <span class="<%s if item.title = fragment then "" else "opacity-80" %> <%s icon_style item.kind %>"></span>
+          </span>
           <% (match item.href with | None -> %>
-            <span class="font-medium text-gray-900"><%s! item.title %></span>
+            <span x-on:click="open = ! open" class="<%s title_style %> <%s if item.title = fragment then "white-200" else "gray-900" %>"><%s! item.title %></span>
           <% | Some href -> %>
-          <a href="<%s href %>" class="font-medium text-gray-900 hover:text-orange-600">
+          <a href="<%s href %>" class="<%s title_style %> overflow-hidden truncate text-gray-900 transition-colors hover:text-orange-600">
             <%s! item.title %>
           </a>
           <% ); %>
-        </span>
-      </summary>
-      <ul class="ml-4">
+        </div>
+      </div>
+      <ul x-show="open" class="ml-1 border-l border-white transition-colors">
         <% children |> List.iter begin fun item -> %>
           <li>
             <%s! nested_render ~path item %>
           </li>
         <% end; %>
       </ul>
-    </details>
-
-let render ~path (t : t) =
-  <div>
-    <% (match t with [] ->  %>
-    <span class="block py-2 text-gray-900">Empty package map</span>
-    <% | _ -> %>
-    <div>
-      <ul class="space-y-4">
-        <% t |> List.iter begin fun item -> %>
-        <li>
-          <%s! nested_render ~path item %>
-        </li>
-        <% end; %>
-      </ul>
     </div>
+
+
+let render
+~(package: Package_intf.package)
+~path
+(maptoc : t)
+=
+  <div class="navmap pb-12">
+    <% (match maptoc with [] ->  %>
+    <span class="block py-2 text-gray-700">Package contains no libraries</span>
+    <% | _ -> %>
+      <a class="py-1 font-medium text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">
+        package <%s package.name %>
+      </a>
+    <ul>
+      <% maptoc |> List.iter begin fun item -> %>
+      <li>
+        <%s! nested_render ~path item %>
+      </li>
+      <% end; %>
+    </ul>
     <% ); %>
   </div>
+  <% (match maptoc with [] ->  %>
+  <% | _ -> %>
+    <div class="py-24">
+    Legend:<br>
+    <span class="<%s icon_style Library %>" style="display:inline-block;background-color:white"></span>Library<br>
+    <span class="<%s icon_style Module %>" style="display:inline-block;background-color:white"></span>Module<br>
+    <span class="<%s icon_style Module_type %>" style="display:inline-block;background-color:white"></span>Module type<br>
+    <span class="<%s icon_style Argument %>" style="display:inline-block;background-color:white"></span>Parameter<br>
+    <span class="<%s icon_style Class %>" style="display:inline-block;background-color:white"></span>Class<br>
+    <span class="<%s icon_style Class_type %>" style="display:inline-block;background-color:white"></span>Class type
+    </div>
+  <% ); %>

--- a/src/ocamlorg_frontend/ocamlorg_frontend.ml
+++ b/src/ocamlorg_frontend/ocamlorg_frontend.ml
@@ -1,6 +1,7 @@
-module Url = Url
+module Breadcrumbs = Breadcrumbs
 module Navmap = Navmap
 module Toc = Toc
+module Url = Url
 include Package_intf
 
 let about () = About.render ()

--- a/src/ocamlorg_frontend/pages/package_documentation.eml
+++ b/src/ocamlorg_frontend/pages/package_documentation.eml
@@ -1,16 +1,37 @@
+let sidebar
+~str_path
+~toc
+~maptoc
+(package : Package_intf.package)
+=
+  <div class="flex flex-col">
+    <div class="xl:hidden mb-6 xl:mb-0">
+      <%s! if (toc != []) then Toc.render toc else "" %>
+    </div>
+    <div class="space-y-6 flex flex-col overflow-x:scroll">
+      <div>
+      <%s! Navmap.render ~package ~path:str_path maptoc %>
+      </div>
+    </div>
+  </div>
+
 let render
 ~documentation_status
 ~title
-~path
+~(path: Breadcrumbs.path_item list)
 ~toc
 ~maptoc
 ~content
 (package : Package_intf.package) =
 let str_path =
   List.map (function
-        | `Module s -> s
-        | `ModuleType s -> s
-        | `FunctorArgument (_, s) -> s) path
+        | Breadcrumbs.Module s -> s
+        | ModuleType s -> s
+        | FunctorArgument (number, s) -> Int.to_string number ^ "-" ^ s
+        | Class s -> s
+        | ClassType s -> s
+        | Library s -> s
+        | Page s -> s) path
 in
 let path_page = match str_path |> String.concat "/" with
                 | "" -> None
@@ -39,17 +60,18 @@ Package_layout.render
       x-show="sidebar" x-transition:enter="transition duration-200 ease-out"
       x-transition:enter-start="-translate-x-full" x-transition:leave="transition duration-100 ease-in"
       x-transition:leave-end="-translate-x-full">
-      <div class="xl:hidden mb-6 xl:mb-0">
-      <%s! if (toc != []) then Toc.render toc else "" %>
-      </div>
-
-      <div class="space-y-2 flex flex-col">
-        <div class="text-sm font-semibold text-gray-500 mb-6">IN THIS PACKAGE</div>
-        <%s! Navmap.render ~path:str_path maptoc %>
-      </div>
+      <%s! sidebar ~str_path ~toc ~maptoc package %>
     </div>
-    <div class="flex-1 overflow-hidden z-0 z- w-full lg:max-w-3xl relative lg:pt-6">
-      <%s! if (maptoc != []) && (List.length path != 0) then Breadcrumbs.render path else "" %>
+    <div class="flex-1 overflow-hidden z-0 z- w-full mx-auto relative pt-6">
+      <% if (maptoc != []) && (List.length path > 1) then (%>
+        <div class="text-body-400">
+          <a title="Package <%s package.name %>" class="py-1 text-xl font-bold text-body-600 hover:text-orange-600 transition-colors" href="<%s Url.package_doc package.name package.version ~page:"index.html" %>">
+          <%s package.name %>
+          </a> &bull;
+          <span title="Library <%s Breadcrumbs.path_item_name (List.hd path) %>"><%s Breadcrumbs.path_item_name (List.hd path) %></span>
+          <%s! Breadcrumbs.render (List.tl path) %>
+        </div>
+      <% ); %>
       <div class="odoc prose prose-orange">
         <%s! content %>
       </div>

--- a/src/ocamlorg_package/lib/module_map.ml
+++ b/src/ocamlorg_package/lib/module_map.ml
@@ -1,6 +1,7 @@
 module String_map = Map.Make (String)
 
 type kind =
+  | Library
   | Module
   | Page
   | Leaf_page

--- a/src/ocamlorg_package/lib/module_map.mli
+++ b/src/ocamlorg_package/lib/module_map.mli
@@ -9,6 +9,7 @@ module String_map : Map.S with type key = string
 
 (** Page kinds as defined by odoc. *)
 type kind =
+  | Library
   | Module
   | Page
   | Leaf_page

--- a/src/ocamlorg_package/lib/ocamlorg_package.ml
+++ b/src/ocamlorg_package/lib/ocamlorg_package.ml
@@ -205,7 +205,9 @@ module Documentation = struct
   type item =
     [ `Module of string
     | `ModuleType of string
-    | `FunctorArgument of int * string ]
+    | `FunctorArgument of int * string
+    | `Class of string
+    | `ClassType of string ]
 
   type t = { toc : toc list; module_path : item list; content : string }
 
@@ -233,6 +235,8 @@ module Documentation = struct
       | [ "argument"; arg_number; arg_name ] -> (
           try Some (`FunctorArgument (int_of_string arg_number, arg_name))
           with Failure _ -> None)
+      | [ "class"; class_name ] -> Some (`Class class_name)
+      | [ "class"; "type"; class_name ] -> Some (`ClassType class_name)
       | _ -> None
     in
     String.split_on_char '/' s |> List.filter_map parse_item

--- a/src/ocamlorg_package/lib/ocamlorg_package.mli
+++ b/src/ocamlorg_package/lib/ocamlorg_package.mli
@@ -70,7 +70,9 @@ module Documentation : sig
   type item =
     [ `Module of string
     | `ModuleType of string
-    | `FunctorArgument of int * string ]
+    | `FunctorArgument of int * string
+    | `Class of string
+    | `ClassType of string ]
 
   type t = { toc : toc list; module_path : item list; content : string }
 end


### PR DESCRIPTION
Do NOT review before #640 is merged. This draft PR will be finalized with screenshots when it is ready for review.

This patch applies some visual and behavioral changes to the "package explorer" in the left sidebar of the package documentation area.

* more compact layout of the package explorer, inspired by file tree views of code editors
* visual highlighting of current entry in the package explorer
* colorful icons on the package explorer facilitate quicker recognition of page type (module, module type, parameter, class, class type)
* breadcrumbs updated to have better visual hierarchy (include package and library) using the color symbolism of the package explorer

